### PR TITLE
Fix build error

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,20 +9,6 @@ handle_exit() {
   else 
     echo "No *test.log found."
   fi
-
-  echo "Cleanup..."
-  rm -rf "${BUILD_DIR}"
-  cd "${SCRIPT_DIR}"
-  rm po/Makefile.in.in
-  rm po/Makevars.template
-  rm po/Rules-quot
-  rm po/boldquot.sed
-  rm po/en@boldquot.header
-  rm po/en@quot.header
-  rm po/insert-header.sin
-  rm po/quot.sed
-  rm po/remove-potcdate.sin
-  echo "Cleanup... done"
   exit "${EXIT_CODE}"
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # name: build.sh
 # desc: Helper script to build teg


### PR DESCRIPTION
The search path for bash is wrong. Also the cleanup code is removed, since the point of this script is to have a configured build directory afterwards, wich can be used to develop the software.

Fixes #20 