### PR TITLE
Adjust the source to be compilable with OpenSUSE.

### DIFF
--- a/client/gui-gnome/preferences.c
+++ b/client/gui-gnome/preferences.c
@@ -21,6 +21,8 @@
  * @file preferences.c
  */
 
+#define _XOPEN_SOURCE 500
+
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
 #endif

--- a/client/gui-gnome/status.c
+++ b/client/gui-gnome/status.c
@@ -20,6 +20,9 @@
 /*
  * functions that manages the status dialog
  */
+
+#define _XOPEN_SOURCE 500
+
 #ifdef HAVE_CONFIG_H
 #  include <config.h>
 #endif

--- a/client/inputfd.c
+++ b/client/inputfd.c
@@ -22,6 +22,7 @@
  * manages the 'in' tokens
  */
 #include <string.h>
+#include <strings.h>
 #include <stdio.h>
 
 #include "../common/net.h"

--- a/client/themes.c
+++ b/client/themes.c
@@ -22,8 +22,11 @@
  * File based in the job example from libxml
  */
 
+#define _XOPEN_SOURCE 500
+
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/common/net.c
+++ b/common/net.c
@@ -24,6 +24,8 @@
  *       y del archivo gnome-net (que ya no existe mas)
  */
 
+#define _POSIX_C_SOURCE 200112L
+
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/un.h>
@@ -34,6 +36,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <netdb.h>

--- a/common/tegdebug.h
+++ b/common/tegdebug.h
@@ -26,11 +26,11 @@
 #define TEGDEBUG
 
 #ifdef TEGDEBUG
-#	define PDEBUG(format, ...) fprintf(stderr, "%s:%d(%s)" format, \
-	                               __FILE__, __LINE__, __PRETTY_FUNCTION__ \
-	                               __VA_OPT__(, __VA_ARGS__))
+#    define PDEBUG(format, ...) fprintf(stderr, "%s:%d(%s)" format, \
+                                       __FILE__, __LINE__, __PRETTY_FUNCTION__, \
+                                       ## __VA_ARGS__)
 #else
-#	define PDEBUG(a)
+#   define PDEBUG(...)
 #endif
 
 #endif /* __TEG_TEGDEBUG_H */

--- a/docker/opensuse
+++ b/docker/opensuse
@@ -1,0 +1,7 @@
+# vim: filetype=dockerfile sw=4 ts=4 et
+FROM opensuse/leap:latest
+
+RUN zypper update && \
+    zypper install -y automake autoconf libtool gcc-c++ gettext make tidy \
+	'pkgconfig(glib-2.0)' 'pkgconfig(libgnomeui-2.0)' 'pkgconfig(libxml-2.0)' \
+	'perl(XML::Parser)' 'pkgconfig(goocanvas-2.0)' pkgconfig xmlto

--- a/server/main.c
+++ b/server/main.c
@@ -21,6 +21,8 @@
  * initialization functions
  */
 
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <strings.h>

--- a/server/options.c
+++ b/server/options.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 
 #include "../common/net.h"
@@ -244,7 +245,7 @@ TEG_STATUS option_seed(int fd, char *str)
 
 		seed = atoi(str);
 		g_game.seed = seed;
-		srandom(seed);
+		srand(seed);
 	}
 
 	option_seed_view();

--- a/server/play.c
+++ b/server/play.c
@@ -25,6 +25,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
Due to a older gcc version on this platform the debug "log" function macro
is adjusted to use a older syntax of variadic macros.

The libc in OpenSuse is more strict about the exported symbols of the headers.
So the code is adjusted to enable those exports, and also include necessary
headers for string handling which are silently included in different headers on
other platforms.

Also there is a fix for a minor bug of seeding the wrong random number
generator.