### PR TITLE
Move data to a shared data directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -57,7 +57,7 @@ tegserver_SOURCES = server/main.c
 tegserver_LDADD = libtegserver.a libtegcommon.a $(INTLLIBS) $(SERVER_LIBS) @XML_LIBS@
 
 libclient_a_CPPFLAGS = @CLIENT_CFLAGS@ @XML_CFLAGS@ -I$(top_srcdir)/common \
-	-DBINDIR=\"$(bindir)\" -DTHEMEDIR=\"$(datadir)/pixmaps/teg_pix/themes/\"
+	-DBINDIR=\"$(bindir)\" -DTHEMEDIR=\"$(datadir)/teg/themes/\"
 libclient_a_SOURCES = \
 	client/client.h		\
 	client/globals.h	\
@@ -87,7 +87,7 @@ libguiclient_a_CPPFLAGS = \
 	-I$(top_srcdir)/client				\
 	-DTEGDATADIR=\"$(datadir)/teg/\"		\
 	-DPIXMAPDIR=\"$(datadir)/pixmaps/\"		\
-	-DTHEMEDIR=\"$(datadir)/pixmaps/teg_pix/themes/\"	\
+	-DTHEMEDIR=\"$(datadir)/teg/themes/\"		\
 	-DG_LOG_DOMAIN=\"TEG\"				\
 	-DDATADIR=\""$(datadir)"\"		   	\
 	-DGNOMELOCALEDIR=\""$(datadir)/locale"\" 

--- a/Makefile.am
+++ b/Makefile.am
@@ -86,10 +86,8 @@ libguiclient_a_CPPFLAGS = \
 	-I$(top_srcdir)/common				\
 	-I$(top_srcdir)/client				\
 	-DTEGDATADIR=\"$(datadir)/teg/\"		\
-	-DPIXMAPDIR=\"$(datadir)/pixmaps/\"		\
 	-DTHEMEDIR=\"$(datadir)/teg/themes/\"		\
 	-DG_LOG_DOMAIN=\"TEG\"				\
-	-DDATADIR=\""$(datadir)"\"		   	\
 	-DGNOMELOCALEDIR=\""$(datadir)/locale"\" 
 
 libguiclient_a_SOURCES = \

--- a/Makefile.am
+++ b/Makefile.am
@@ -85,6 +85,7 @@ libguiclient_a_CPPFLAGS = \
 	@XML_CFLAGS@					\
 	-I$(top_srcdir)/common				\
 	-I$(top_srcdir)/client				\
+	-DTEGDATADIR=\"$(datadir)/teg/\"		\
 	-DPIXMAPDIR=\"$(datadir)/pixmaps/\"		\
 	-DTHEMEDIR=\"$(datadir)/pixmaps/teg_pix/themes/\"	\
 	-DG_LOG_DOMAIN=\"TEG\"				\

--- a/client/gui-gnome/callbacks.c
+++ b/client/gui-gnome/callbacks.c
@@ -280,7 +280,7 @@ void on_about_activate(GtkMenuItem *menuitem, gpointer user_data)
 
 	{
 		gchar* logo_filename = NULL;
-		logo_filename = g_strdup(PIXMAPDIR"/teg_icono.png");
+		logo_filename = g_strdup(TEGDATADIR "teg_icono.png");
 
 		if(logo_filename != NULL) {
 			pixbuf = gdk_pixbuf_new_from_file(logo_filename, NULL);

--- a/client/gui-gnome/support.c
+++ b/client/gui-gnome/support.c
@@ -74,15 +74,8 @@ void generic_window_set_parent(GtkWidget * dialog, GtkWindow   * parent)
 char * load_pixmap_file(char *name)
 {
 	char *filename = NULL;
-	char *f = NULL;
 
-	f = g_strconcat("teg_pix/", name, NULL);
-	if(f == NULL) {
-		return NULL;
-	}
-
-	filename = g_strconcat(PIXMAPDIR, f, NULL);
-	g_free(f);
+	filename = g_strconcat(TEGDATADIR, name, NULL);
 	return filename;
 }
 

--- a/client/teg_pix/Makefile.am
+++ b/client/teg_pix/Makefile.am
@@ -1,4 +1,4 @@
-pixmapdir=$(datadir)/pixmaps/teg_pix
+pixmapdir=$(datadir)/teg
 appicondir=$(datadir)/pixmaps
 
 pixmap_DATA =	\

--- a/client/themes.c
+++ b/client/themes.c
@@ -776,7 +776,7 @@ TEG_STATUS theme_enum_themes(pTInfo pTI)
 	/* ~/.teg/themes */
 	snprintf(lugares[1], sizeof(lugares[1])-1, "%s/%s/themes", g_get_home_dir(), TEG_DIRRC);
 
-	/* /usr/local/share/pixmap/teg_pix/themes */
+	/* /usr/local/share/teg/themes */
 	strncpy(lugares[2], THEMEDIR, sizeof(buf)-1);
 
 

--- a/client/themes/classic/Makefile.am
+++ b/client/themes/classic/Makefile.am
@@ -1,4 +1,4 @@
-pixmapdir=$(datadir)/pixmaps/teg_pix/themes/classic
+pixmapdir=$(datadir)/teg/themes/classic
 
 pixmap_DATA =	\
 	teg_theme.xml		\

--- a/client/themes/draco/Makefile.am
+++ b/client/themes/draco/Makefile.am
@@ -1,4 +1,4 @@
-pixmapdir=$(datadir)/pixmaps/teg_pix/themes/draco
+pixmapdir=$(datadir)/teg/themes/draco
 
 pixmap_DATA =	\
 	teg_theme.xml		\

--- a/client/themes/m2/Makefile.am
+++ b/client/themes/m2/Makefile.am
@@ -1,4 +1,4 @@
-pixmapdir=$(datadir)/pixmaps/teg_pix/themes/m2
+pixmapdir=$(datadir)/teg/themes/m2
 
 pixmap_DATA =	\
 	Africa-Egipto Africa-Etiopia Africa-Madagascar Africa-Sahara Africa-Sudafrica Africa-Zaire	\

--- a/client/themes/modern/Makefile.am
+++ b/client/themes/modern/Makefile.am
@@ -1,4 +1,4 @@
-pixmapdir=$(datadir)/pixmaps/teg_pix/themes/modern
+pixmapdir=$(datadir)/teg/themes/modern
 
 pixmap_DATA =	\
 	teg_theme.xml		\

--- a/client/themes/sentimental/Makefile.am
+++ b/client/themes/sentimental/Makefile.am
@@ -1,4 +1,4 @@
-pixmapdir=$(datadir)/pixmaps/teg_pix/themes/sentimental
+pixmapdir=$(datadir)/teg/themes/sentimental
 
 pixmap_DATA =	\
 	Africa-Egipto Africa-Etiopia Africa-Madagascar Africa-Sahara \


### PR DESCRIPTION
Move the shared data of teg (i.e. pixmaps and themes) to a shared data directory from the public pixmaps location. This is done as they are teg private data rather than public pixmaps.